### PR TITLE
Optimize layout for smaller display sizes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ documents
 .vscode/
 manifest*.json
 navData.js
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:7.2.0
+
+MAINTAINER Phillip Wittrock <pwittroc@google.com>
+
+ADD . /brodocs
+WORKDIR /brodocs
+
+RUN npm install
+
+CMD ./runbrodocs.sh

--- a/brodoc.js
+++ b/brodoc.js
@@ -180,8 +180,9 @@ function generateDoc(navContent, bodyContent, codeTabContent) {
 <html>
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>${config.title}</title>
-<link rel="shortcut icon" href="favicon.ico" type="image/vnd.microsoft.icon">
+<link rel="icon" href="/images/favicon.png">
 <!-- Latest compiled and minified CSS -->
 <link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.min.css">
 <link rel="stylesheet" href="node_modules/font-awesome/css/font-awesome.min.css" type="text/css">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,88 @@
+{
+  "name": "brodocs",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bootstrap": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
+      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
+    "ejs": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
+      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
+      "dev": true
+    },
+    "font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
+    },
+    "highlight.js": {
+      "version": "9.18.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.1.tgz",
+      "integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==",
+      "dev": true
+    },
+    "jquery": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+    },
+    "jquery.scrollto": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/jquery.scrollto/-/jquery.scrollto-2.1.2.tgz",
+      "integrity": "sha1-51gNnHrEbvW7JTGUg/b0VxP9fGw=",
+      "requires": {
+        "jquery": ">=1.8"
+      }
+    },
+    "marked": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+      "dev": true
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
+    "minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+    },
+    "node-static": {
+      "version": "0.7.11",
+      "resolved": "https://registry.npmjs.org/node-static/-/node-static-0.7.11.tgz",
+      "integrity": "sha512-zfWC/gICcqb74D9ndyvxZWaI1jzcoHmf4UTHWQchBNuNMxdBLJMDiUgZ1tjGLEIe/BMhj2DxKD8HOuc2062pDQ==",
+      "requires": {
+        "colors": ">=0.6.0",
+        "mime": "^1.2.9",
+        "optimist": ">=0.3.4"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    }
+  }
+}

--- a/runbrodocs.sh
+++ b/runbrodocs.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+rm -rf ./documents/*
+cp /manifest/manifest.json ./manifest.json
+cp /source/* ./documents/
+node brodoc.js
+cp -r ./* /build/

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -110,13 +110,12 @@ light grey - rgb(161, 160, 158)
 body > #wrapper {
     display: block;
     padding-bottom: 500px;
-    background-image: linear-gradient(90deg, #FFFFFF 63%, rgb(48, 48, 48) 63%);
 }
 
 #sidebar-wrapper {
-    display: block;
+    display: none;
     height: 100%;
-    width: 20%;
+    width: 220px;
     position: fixed;
     z-index: 1;
     top: 0;
@@ -124,7 +123,6 @@ body > #wrapper {
     background-color: whitesmoke;
     border-right: 2px solid slategrey;
     overflow-x: hidden;
-    padding-top: 60px;
 }
 
 #sidebar-wrapper a {
@@ -140,7 +138,7 @@ body > #wrapper {
 }
 
 #sidebar-wrapper a.selected {
-    font-style: bold;
+    font-weight: bold;
     color: whitesmoke;
     border: 1px solid rgb(161, 160, 158);
     background-color: rgb(51, 113, 227);
@@ -163,29 +161,19 @@ body > #wrapper {
     text-decoration: underline;
 }
 
-#page-content-wrapper {
-    margin-left: 20%;
-    padding-top: 60px;
-}
-
 .body-content h1, .body-content h2 {
-    width: 52%;
     clear: both;
     border-bottom: 3px solid lightslategrey;
 }
 
 .body-content > h3, .body-content > h4, .body-content > h5, .body-content > h6, .body-content > p, .body-content > aside, .body-content > ul > li, .body-content > ul > li {
-    width: 52%;
     padding-top: 20px;
-}
-
-.body-content table {
-    width: 52%;
 }
 
 .body-content table tr td:not(:first-child) {
     overflow-wrap: break-word;
     word-wrap: break-word;
+    word-break: break-word;
 }
 
 .body-content table tr td a {
@@ -204,38 +192,39 @@ body > #wrapper {
     border-radius: 5px;
 }
 
-.body-content pre.code-block {
-    margin-bottom: 80px;
-}
-
 .body-content blockquote p, .body-content pre {
     color: black;
     font-size: 13px;
 }
 
-.body-content blockquote.code-block {
+.body-content blockquote.code-block.example {
     background: lightsteelblue;
+    padding: 10px;
+    border-radius: 5px 5px 0 0;
+    margin-bottom: 0;
+    font-size: 1.25rem;
+    font-weight: bold;
+    border-left: none;
+    display: block;
+}
+
+.body-content pre.example {
+    border-radius: 0 0 5px 5px;
+    color: #000;
+    background: #eee;
+    overflow-x: auto;
+    display: block;
 }
 
 .body-content pre.code-block code {
-  overflow: auto;
-  overflow-wrap: normal;
-  word-wrap: normal;
-  white-space: pre;
-}
-
-.code-block {
-    display: none;
-    width: 45%;
-    float: right;
-    clear: right;
-}
-
-.code-block.active {
-    display: initial;
+    overflow: auto;
+    overflow-wrap: normal;
+    word-wrap: normal;
+    white-space: pre;
 }
 
 #code-tabs-wrapper {
+    display: none;
     width: 35%;
     height: 60px;
     position: fixed;
@@ -260,10 +249,77 @@ body > #wrapper {
 
 #code-tabs-wrapper .tab-selected {
     background: rgb(51, 113, 227);
-    font-style: bold;
+    font-weight: bold;
     border-radius: 5px;
 }
 
 .side-nav a {
     color: black;
+}
+
+hr {
+    clear: both;
+}
+
+#page-content-wrapper {
+    width: 100%;
+    overflow-x: auto;
+}
+
+/* Medium display, show sidebar */
+@media screen and (min-width: 456px) {
+    #sidebar-wrapper {
+        display: block;
+    }
+
+    #page-content-wrapper {
+        padding-left: 235px;
+    }
+}
+
+/* Large display, split examples into the far right column */
+@media screen and (min-width: 992px) {
+    #wrapper {
+        background-image: linear-gradient(90deg, #FFFFFF 63%, rgb(48, 48, 48) 63%);
+    }
+
+    #sidebar-wrapper {
+        width: 20%;
+    }
+
+    #page-content-wrapper {
+        padding-left: 21%;
+    }
+
+    .body-content h1, .body-content h2 {
+        width: 52%;
+        clear: both;
+    }
+
+    .body-content > h3, .body-content > h4, .body-content > h5, .body-content > h6, .body-content > p, .body-content > ul > li, .body-content > ul > li {
+        width: 52%;
+    }
+
+    .body-content table {
+        width: 52%;
+    }
+
+    .body-content .code-block {
+        width: 45%;
+        float: right;
+        clear: right;
+    }
+
+    .code-block {
+        display: none;
+    }
+
+    .code-block.active {
+        display: initial;
+    }
+
+    #code-tabs-wrapper {
+        display: inline-block;
+        width: 35%;
+    }
 }


### PR DESCRIPTION
cc @pwittrock 

The motivation for these changes is [kubernetes website issue 19519](https://github.com/kubernetes/website/issues/19519) where some of the tables overlap into the examples when display is narrow like on an ipad for example.

Here is list of what was changed in this PR:

- Added meta viewport tag to html output.
- Changed icon link tag to use recommended syntax and changed path to match kubernetes doc favicon path.
- Updated stylesheet to be "mobile-first", only showing sidebar for tablet and above screen size, and only showing separate example column for desktop and above screen size, otherwise, showing examples inline with the command descriptions.
- Visually connect the blockquote and example to make them appear more together when they show inline.
A few other minor fixes in css attributes.
- Added Dockerfile and supporting script runbrodocs.sh <-- Adding the dockerfile to the repo should let docker hub point directly to the repo to build the container

I realize it looks like I drastically changed the css around, but I tried to keep as much untouched as possible.  Much of the change was from moving selectors inside media queries

---
Preview of kubectl reference rendered using this vestion of brodocs:
https://deploy-preview-19540--kubernetes-io-master-staging.netlify.com/docs/reference/generated/kubectl/kubectl-commands

For comprison, here is the live current version of kubectl reference:
https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands